### PR TITLE
sip-push: wordsmithing abstract, intro

### DIFF
--- a/draft-ietf-sipcore-sip-push.xml
+++ b/draft-ietf-sipcore-sip-push.xml
@@ -50,13 +50,14 @@
     <keyword>Notification</keyword>
     <abstract>
       <t>
-        This document describes how a Push Notification Service (PNS) can be used to wake
-        suspended Session Initiation Protocol (SIP) User Agents (UAs), using push notifications, 
-        for the UA to be able to send binding-refresh REGISTER requests and to receive incoming SIP requests. 
-        The document defines new SIP URI parameters and new feature-capability
-        indicators that can be used in SIP messages to indicate support of the mechanism defined in this 
-        document, to exchange PNS information between the SIP User Agent (UA) and the SIP entity that will 
-        request that push notifications are sent to the UA, and to trigger such push notification requests.
+        This document describes how a Push Notification Service (PNS) can be used to wake a
+        suspended Session Initiation Protocol (SIP) User Agent (UA) with push notifications, 
+        and also describes how the UA can send binding-refresh REGISTER requests and receive 
+        incoming SIP requests in an environment in which the UA may be suspended. The document 
+        defines new SIP URI parameters to exchange PNS information between the UA and the SIP 
+        entity that will then request that push notifications be sent to the UA, and to trigger 
+        such push notification requests. The document also defines new feature-capability
+        indicators that can be used to indicate support of this mechanism.
       </t>
     </abstract>
   </front>
@@ -64,64 +65,75 @@
   <middle>
     <section title="Introduction" toc="default">
       <t>
-        In order to save resources (e.g., battery life) some devices (especially mobile devices)
-        and operating systems will suspend applications when not used. In some cases,
-        internal timers cannot be used to wake such applications, nor will incoming network
-        traffic wake the application. Instead, one way to wake the application is by using a
-        Push Notification Service (PNS). A PNS is a service from where a user application can
-        receive messages, referred to as push notifications, requested by other applications. 
-        Push notifications might contain payload data, depending on the application. An application 
-        can request that a push notification is sent to a single user application, or to multiple
-        user applications.
+        In order to save resources such as battery life, some devices (especially mobile devices)
+        and operating systems will suspend an application that is not in use. A suspended application 
+        might not be able to wake itself with internal timers and might not be awakened by incoming 
+        network traffic. In such an environment, a Push Notification Service (PNS) is used to wake 
+        the application. A PNS is a service that sends messages requested by other applications 
+        to a user application in order to wake the user application. These messages are called push 
+        notifications.  Push notifications might contain payload data, depending on the application.  
+        An application can request that a push notification is sent to a single user application or 
+        to multiple user applications.
       </t>
       <t>  
-        Typically each operating system uses a dedicated PNS. 
-        For example, Apple iOS devices use the Apple Push Notification service (APNs)
-        while Android devices use the Firebase Cloud Messaging (FCM) service.
+        Typically each operating system uses a dedicated PNS. Different PNSs exist today. 
+        Some are based on the standardized mechanism defined in <xref target="RFC8030"/>, while 
+        others are proprietary. For example, Apple iOS devices use the Apple Push Notification 
+        service (APNs) while Android devices use the Firebase Cloud Messaging (FCM) service.
+        Each PNS uses PNS-specific terminology and function names. The terminology in this 
+        document is meant to be PNS-independent. If the PNS is based on <xref target="RFC8030"/>, 
+        the SIP proxy takes the role of the application server.
       </t>
       <t>
-        Because of the restrictions above, Session Initiation Protocol (SIP) User Agents (UAs)
-        <xref target="RFC3261"/> can not be awoken, in order to send binding-refresh SIP REGISTER
-        requests and to receive incoming SIP requests, without using a PNS to wake the UA
-        in order to perform those functions. 
+        When a Session Initiation Protocol (SIP) User Agent (UA)<xref target="RFC3261"/> is 
+        suspended in such an environment, it is unable to send binding-refresh SIP REGISTER 
+        requests, unable to receive incoming SIP requests, and might not be able to use internal 
+        timers to wake itself. A suspended UA will not be able to maintain connections e.g.,
+        using the SIP Outbound Mechanism <xref target="RFC5626"/> because it cannot send periodic 
+        keep-alive messages. A PNS is needed to wake the SIP UA so that the UA can perform these 
+        functions.
       </t>
       <t>
-        Also, without being able to use internal timers in order to wake applications, a UA 
-        will not be able to maintain connections e.g., using the SIP Outbound Mechanism 
-        <xref target="RFC5626"/>, as it requires the UA to send periodic keep-alive messages.
-      </t>
-      <t>
-        This document describes how PNSs can be used to wake suspended UAs, using push notifications, to be able to send
-        binding-refresh REGISTER requests and to receive incoming SIP requests. The document defines 
-        new SIP URI parameters and new feature-capability indicators <xref target="RFC6809"/> 
-        that can be used in SIP messages to indicate support of the mechanism defined in this document, 
-        to exchange PNS information between the UA and the SIP entity (realized as a SIP proxy in this document) 
-        that will request that push notifications are sent to the UA, and to request such push notification requests.
+        This document describes how a PNS can be used to wake a suspended UA, using push 
+        notifications, so that the UA can be able to send binding-refresh REGISTER requests 
+        and to receive incoming SIP requests. The document defines new SIP URI parameters and 
+        new feature-capability indicators <xref target="RFC6809"/> that can be used in SIP 
+        messages to indicate support of the mechanism defined in this document, to exchange 
+        PNS information between the UA and the SIP entity (realized as a SIP proxy in this 
+        document) that will request that push notifications are sent to the UA, and to 
+        request such push notification requests.
       </t>  
       <t>
-        NOTE: Even if a UA is able to be awakened by other means than receiving push notifications (e.g., by using internal timers) in order to 
-        send periodic binding-refresh REGISTER requests, it might still be useful to suspend the application
-        between the sending of binding-refresh requests (as it will save battery life) and use push notifications
+        NOTE: Even if a UA is able to be awakened by means other than receiving push 
+        notifications (e.g., by using internal timers) in order to send periodic binding-refresh 
+        REGISTER requests, it might still be useful to suspend the UA between the sending of 
+        binding-refresh requests (as it will save battery life) and use push notifications
         to wake the UA when an incoming SIP request UA arrives.
       </t>
       <t>
-        When a UA registers to a PNS, it will receive a unique Push Resource ID (PRID)
-        associated with the push notification registration. The UA will use a REGISTER request to
-        provide the PRID to the SIP proxy that will request push that notifications are sent to the UA.
+        When a UA registers with a PNS <!-- ajm: Figure 1 labels this a subscription to the PNS rather than a 
+        registration -->, it will receive a unique Push Resource ID (PRID)
+        associated with the push notification registration. The UA will use a REGISTER request 
+        to provide the PRID to the SIP proxy, which will then request that push notifications 
+        are sent to the UA.
       </t>
+      <!-- ajm: I heavily modified this paragraph below to match what Figure 1 shows. Please check
+           for accuracy. -->
       <t>
-        When the proxy receives  
-        a SIP request for a new dialog or a stand-alone SIP request addressed towards a UA, 
-        or when the proxy determines that the UA needs to send a binding-refresh REGISTER request, the proxy will 
-        request that a push notification is sent to the UA, using the PNS of the UA. Once the UA receives 
-        the push notification, it will be able to send a binding-refresh REGISTER request and receive 
-        the incoming SIP request. The proxy will receive the REGISTER request. If the push notification request was
-        triggered by a SIP request addressed towards the UA (see above), once the REGISTER request has been 
-        accepted by the SIP registrar <xref target="RFC3261"/>, and the associated SIP 2xx response has been forwarded by the proxy towards the UA, 
-        the proxy can forward the SIP request towards the UA using normal SIP routing procedures. In some cases the proxy can forward the SIP
-        request without waiting for the SIP 2xx response to the REGISTER request. Note that this mechanism necessarily adds
-        delay to responding to requests requiring push notification. The consequences of that delay are discussed
-        in <xref target="section.proxy.req.oth"/>.
+        When the SIP proxy receives a SIP request for a new dialog or a stand-alone SIP request 
+        addressed towards a UA, or when the SIP proxy determines that the UA needs to send a 
+        binding-refresh REGISTER request, the SIP proxy will send a push request containing the 
+        PRID of the UA to the PNS, which will then send a push notification to the UA. Once the 
+        UA receives the push notification, it will be able to send a binding-refresh REGISTER 
+        request. The proxy receives the REGISTER request from the UA and forwards it to the SIP 
+        registrar <xref target="RFC3261"/>. After accepting the REGISTER request, the SIP registrar 
+        sends a 2xx response to the proxy, which forwards the response to the UA. If the push 
+        notification request was triggered by a SIP request addressed towards the UA, the proxy 
+        can then forward the SIP request to the UA using normal SIP routing procedures. In some 
+        cases the proxy can forward the SIP request without waiting for the SIP 2xx response to 
+        the REGISTER request from the SIP registrar. Note that this mechanism necessarily adds 
+        delay to responding to requests requiring push notification. The consequences of that 
+        delay are discussed in <xref target="section.proxy.req.oth"/>.
       </t>
       <t>
         If there are Network Address Translators (NATs) between the UA and the proxy, the REGISTER request sent by the UA will create NAT bindings 
@@ -132,19 +144,12 @@
         SIP request that triggered the push notification to reach the UA.
       </t>
       <t>
-        Different PNSs exist today. Some are based on the standardized mechanism defined in 
-        <xref target="RFC8030"/>, while others are proprietary (e.g., the Apple Push Notification 
-        service). <xref target="fig-sip-pn-arch"/> shows the generic push notification architecture 
+        <xref target="fig-sip-pn-arch"/> shows the generic push notification architecture 
         supported by the mechanism in this document.
       </t>
       <t>
-        Each PNS uses PNS-specific terminology and function names. The terminology in this document is meant to 
-        be PNS-independent. If the PNS is based on <xref target="RFC8030"/>, the SIP proxy takes the role of 
-        the application server.
-      </t>
-      <t>
-        The proxy MUST be in the signalling path of REGISTER requests sent by the UA towards the registrar, and of SIP requests (for a new dialog or a stand-alone)
-        forwarded by the proxy responsible for the UA's domain (sometimes referred to as home proxy, S-CSCF, etc) towards the UA. The proxy can also be co-located with 
+        The SIP proxy MUST be in the signalling path of REGISTER requests sent by the UA towards the registrar, and of SIP requests (for a new dialog or a stand-alone)
+        forwarded by the proxy responsible for the UA's domain (sometimes referred to as home proxy, S-CSCF, etc.) towards the UA. The proxy can also be co-located with 
         the proxy responsible for the UA's domain. This will also ensure that the Request-URI of SIP requests (for a new dialog or a stand-alone) can be matched against
         contacts in REGISTER requests.
       </t>


### PR DESCRIPTION
I've also added XML comments (noted with ajm) where I have questions and comments.  The two issues are:
  o  Figure 1 labels the initial step as a subscription to the PNS rather than a registration, which is the term used in the text. 
  o  I seriously worked over the paragraph that starts "When the proxy receives a SIP request", expanding it to make it cover more steps that are found in Figure 1. Please double-check.